### PR TITLE
Refactor todo app test to run in parallel

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -2,7 +2,7 @@ interface ImportMetaEnv {
   // CouchDB Variables
   readonly DB_SSL: string;
   readonly DB_DOMAIN: string;
-  readonly DB_PORT: number;
+  readonly DB_PORT: string;
   readonly DB_NAME: string;
   readonly DB_PASS: string;
   readonly DB_USER: string;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -58,7 +58,6 @@ const config: PlaywrightTestConfig = {
       use: {
         ...devices["Desktop Firefox"],
       },
-      testIgnore: "demo-todo-app.spec.ts",
     },
 
     {
@@ -66,7 +65,6 @@ const config: PlaywrightTestConfig = {
       use: {
         ...devices["Desktop Safari"],
       },
-      testIgnore: "demo-todo-app.spec.ts",
     },
 
     /* Test against mobile viewports. */

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -1,5 +1,22 @@
 import CouchDB from "../lib/CouchDB";
 
-const db = new CouchDB();
+// get defaults from environment
+const scheme = import.meta.env.DB_SSL === "true" ? "https" : "http";
+const domain = import.meta.env.DB_DOMAIN;
+const port = import.meta.env.DB_PORT;
+const dbName = import.meta.env.DB_NAME;
+const user = import.meta.env.DB_USER;
+const pass = import.meta.env.DB_PASS;
+const logLevelEnv: string = import.meta.env.LOGLEVEL?.toUpperCase() || "DEBUG";
+
+const db = new CouchDB({
+  scheme,
+  domain,
+  port,
+  dbName,
+  user,
+  pass,
+  logLevelEnv,
+});
 
 export default db;

--- a/src/lib/Logger.ts
+++ b/src/lib/Logger.ts
@@ -7,18 +7,25 @@ enum LogLevel {
   DEBUG,
 }
 
-const logLevelEnv: string = import.meta.env.LOGLEVEL?.toUpperCase() || "DEBUG";
-const logLevel: LogLevel = LogLevel[logLevelEnv];
+class Logger {
+  #logLevel: LogLevel;
 
-export default function Log(message: any, level: LogLevel) {
-  if (level <= logLevel) {
-    if (level === LogLevel.WARNING)
-      return console.warn(LogLevel[level], message);
-    if (level === LogLevel.INFO) return console.info(LogLevel[level], message);
-    if (level === LogLevel.ERROR)
-      return console.error(LogLevel[level], message);
-    return console.log(LogLevel[level], message);
+  constructor(logLevelEnv: string) {
+    this.#logLevel = LogLevel[logLevelEnv];
+  }
+
+  Log(message: any, level: LogLevel) {
+    if (level <= this.#logLevel) {
+      if (level === LogLevel.WARNING)
+        return console.warn(LogLevel[level], message);
+      if (level === LogLevel.INFO)
+        return console.info(LogLevel[level], message);
+      if (level === LogLevel.ERROR)
+        return console.error(LogLevel[level], message);
+      return console.log(LogLevel[level], message);
+    }
   }
 }
 
+export default Logger;
 export { LogLevel };

--- a/src/pages/api/allDocs.ts
+++ b/src/pages/api/allDocs.ts
@@ -1,7 +1,9 @@
 import db from "../../db/db";
 
-export async function get() {
-  const data = await db.allDocs();
+export async function get({ request }) {
+  const dbName = request.headers.get("db_name") || import.meta.env.DB_NAME;
+
+  const data = await db.allDocs({ dbName });
 
   return new Response(JSON.stringify(data), {
     status: 200,

--- a/src/pages/api/couchInfo.ts
+++ b/src/pages/api/couchInfo.ts
@@ -1,7 +1,9 @@
 import db from "../../db/db";
 
-export async function get() {
-  const data = await db.getCouchDbInfo();
+export async function get({ request }) {
+  const dbName = request.headers.get("db_name") || import.meta.env.DB_NAME;
+
+  const data = await db.getCouchDbInfo({ dbName });
 
   return new Response(JSON.stringify(data), {
     status: 200,

--- a/src/pages/api/dbInfo.ts
+++ b/src/pages/api/dbInfo.ts
@@ -1,7 +1,9 @@
 import db from "../../db/db";
 
-export async function get() {
-  const data = await db.getDbInfo();
+export async function get({ request }) {
+  const dbName = request.headers.get("db_name") || import.meta.env.DB_NAME;
+
+  const data = await db.getDbInfo({ dbName });
 
   return new Response(JSON.stringify(data), {
     status: 200,

--- a/src/pages/api/getDoc/[id].ts
+++ b/src/pages/api/getDoc/[id].ts
@@ -1,7 +1,9 @@
 import db from "../../../db/db";
 
-export async function get({ params }) {
-  const data = await db.getDoc(params.id);
+export async function get({ params, request }) {
+  const dbName = request.headers.get("db_name") || import.meta.env.DB_NAME;
+
+  const data = await db.getDoc(params.id, { dbName });
 
   return new Response(JSON.stringify(data), {
     status: 200,

--- a/src/pages/api/upsertDoc.ts
+++ b/src/pages/api/upsertDoc.ts
@@ -1,9 +1,11 @@
 import db from "../../db/db";
 
 export async function post({ request }) {
+  const dbName = request.headers.get("db_name") || import.meta.env.DB_NAME;
+
   const data = await request.json();
 
-  const resp = await db.upsertDoc(data);
+  const resp = await db.upsertDoc(data, { dbName });
 
   return new Response(JSON.stringify(resp), {
     status: 200,


### PR DESCRIPTION
This PR refactors the todo-app test and provides an example how to implement parallel/concurrent tests using the database.

The basic strategy is to create a database for every test, context, and browser.

This allows tests to run in isolation from each other and enables running in parallel with many workers and browsers.

Incidental refactors that were required in order to make this PR possible included the CouchDB Library, the Logger, and the API endpoints to allow a custom db header.